### PR TITLE
Add auth collection slug for PayloadCMS API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 
 ## Credentials
 
-Create an API key in Payload CMS and enter your CMS base URL and key in the node credentials. The node sends requests with an `Authorization` header in the format `<collection-slug> API-Key <token>` as required by Payload CMS.
+Create an API key in Payload CMS and enter your CMS base URL, the API key enabled collection slug, and the key itself in the node credentials. The node sends requests with an `Authorization` header in the format `<api-key-collection> API-Key <token>` as required by Payload CMS.
 
 ## Development
 

--- a/credentials/PayloadCmsApi.credentials.ts
+++ b/credentials/PayloadCmsApi.credentials.ts
@@ -5,24 +5,32 @@ export class PayloadCmsApi implements ICredentialType {
 	displayName = 'Payload CMS API';
 	documentationUrl = 'https://payloadcms.com/docs/authentication/api-keys';
 	dummy = false;
-	properties: INodeProperties[] = [
-		{
-			displayName: 'Base URL',
-			name: 'baseUrl',
-			description: 'Root URL of your Payload installation, e.g. https://cms.example.com',
-			type: 'string',
-			default: '',
-			placeholder: 'https://cms.example.com',
-		},
-		{
-			displayName: 'API Key',
-			name: 'apiKey',
-			description: 'API key created in Payload ➜ Access ➜ API Keys',
-			type: 'string',
-			typeOptions: {
-				password: true,
-			},
-			default: '',
-		},
-	];
+        properties: INodeProperties[] = [
+                {
+                        displayName: 'Base URL',
+                        name: 'baseUrl',
+                        description: 'Root URL of your Payload installation, e.g. https://cms.example.com',
+                        type: 'string',
+                        default: '',
+                        placeholder: 'https://cms.example.com',
+                },
+                {
+                        displayName: 'API Key',
+                        name: 'apiKey',
+                        description: 'API key created in Payload ➜ Access ➜ API Keys',
+                        type: 'string',
+                        typeOptions: {
+                                password: true,
+                        },
+                        default: '',
+                },
+                {
+                        displayName: 'Auth Collection Slug',
+                        name: 'authCollection',
+                        description: 'Slug of the collection that has auth.useAPIKey enabled',
+                        type: 'string',
+                        default: 'users',
+                        placeholder: 'users',
+                },
+        ];
 }

--- a/helpers/GenericFunctions.ts
+++ b/helpers/GenericFunctions.ts
@@ -5,7 +5,6 @@ export async function payloadCmsApiRequest(
   this: IExecuteFunctions | ILoadOptionsFunctions,
   method: string,
   endpoint: string,
-  collectionSlug: string,
   body: object = {},
   qs: object = {},
   headers: Record<string, string | number> = {},
@@ -13,9 +12,10 @@ export async function payloadCmsApiRequest(
 ) {
   const credentials = await this.getCredentials('payloadCmsApi');
   const baseUrl = (credentials.baseUrl as string).replace(/\/$/, '');
+  const authCollection = credentials.authCollection as string;
 
   const defaultHeaders = {
-    Authorization: `${collectionSlug} API-Key ${credentials.apiKey}`,
+    Authorization: `${authCollection} API-Key ${credentials.apiKey}`,
     'Content-Type': 'application/json',
   };
 

--- a/nodes/PayloadCms/PayloadCms.node.ts
+++ b/nodes/PayloadCms/PayloadCms.node.ts
@@ -180,7 +180,6 @@ export class PayloadCms implements INodeType {
                                         this,
                                         method,
                                         endpoint,
-                                        collectionSlug,
                                         body,
                                         qs,
                                 );


### PR DESCRIPTION
## Summary
- require auth collection slug in credentials
- adjust Authorization header logic to use the collection slug for API keys
- update node request helper signature
- document new credential field

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853082b35a4832c9750b98f6e7a78da