### PR TITLE
Add schema template operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 - Get a collection entry
 - Get many collection entries
 - Update collection entries
-- Fetch collection schema for JSON pre-fill
+- Get collection schema template
 
 ## Credentials
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-payloadcms",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-payloadcms",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-payloadcms",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "n8n community node for interacting with Payload CMS",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
## Summary
- expose new "Get Template" operation for collections
- handle fetching template via GraphQL when selected
- mention new operation in README
- bump version to 0.1.3

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685321fb198c832c8a889770d4f49ba5